### PR TITLE
Fix Vercel serverless deployment issue

### DIFF
--- a/server.js
+++ b/server.js
@@ -491,8 +491,11 @@ app.get('/api/health', (req, res) => {
   res.json({ status: 'ok' });
 });
 
-app.listen(PORT, () => {
-  console.log(`Server running on port ${PORT}`);
-});
+// Only start server if not in Vercel serverless environment
+if (process.env.NODE_ENV !== 'production' || !process.env.VERCEL) {
+  app.listen(PORT, () => {
+    console.log(`Server running on port ${PORT}`);
+  });
+}
 
 module.exports = app;

--- a/vercel.json
+++ b/vercel.json
@@ -9,7 +9,7 @@
   "routes": [
     {
       "src": "/(.*)",
-      "dest": "server.js"
+      "dest": "/server.js"
     }
   ]
 }


### PR DESCRIPTION
- Conditionally call app.listen() only when not in Vercel
- Update vercel.json route destination path
- Fixes "Cannot GET /" error on deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)