### PR TITLE
Fix credential field name mismatch causing 'username is required' error

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -369,7 +369,7 @@ app.post('/api/numbers/:sid/configure-voice', async (req, res) => {
     const baseUrl = `${protocol}://${host}`;
 
     // Configure phone number for voice
-    const client = twilio(account.account_sid, account.auth_token);
+    const client = twilio(account.accountSid, account.authToken);
     await client.incomingPhoneNumbers(sid).update({
       voiceUrl: `${baseUrl}/voice`,
       voiceMethod: 'POST',
@@ -420,7 +420,7 @@ app.post('/api/numbers/:sid/configure-sms', async (req, res) => {
     const baseUrl = `${protocol}://${host}`;
 
     // Configure phone number for SMS
-    const client = twilio(account.account_sid, account.auth_token);
+    const client = twilio(account.accountSid, account.authToken);
     await client.incomingPhoneNumbers(sid).update({
       smsUrl: `${baseUrl}/sms`,
       smsMethod: 'POST',
@@ -498,7 +498,7 @@ app.post('/api/numbers/:sid/validate', async (req, res) => {
     const baseUrl = `${protocol}://${host}`;
 
     // Fetch actual configuration from Twilio
-    const client = twilio(account.account_sid, account.auth_token);
+    const client = twilio(account.accountSid, account.authToken);
     const twilioNumber = await client.incomingPhoneNumbers(sid).fetch();
 
     // Validate voice configuration


### PR DESCRIPTION
Issue:
When clicking "Configure Voice" or "Configure SMS" on a phone number, users encountered error: "username is required"

Root Cause:
- Credentials saved as accountSid/authToken (camelCase) in /api/setup/voice/credentials
- Phone number endpoints tried to access account.account_sid/account.auth_token (snake_case)
- Twilio SDK received undefined values, triggering "username is required" error

Fixed Endpoints:
- POST /api/numbers/:sid/configure-voice
- POST /api/numbers/:sid/configure-sms
- POST /api/numbers/:sid/validate

All now correctly use account.accountSid and account.authToken (camelCase) to match the saved credential format.

This ensures both voice and SMS configuration work properly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)