### PR TITLE
Fix incoming call routing - browser now rings on incoming calls

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -661,11 +661,11 @@ app.post('/voice', async (req, res) => {
     const voiceNumber = numbers.find(n => n.voice_config && n.voice_config.webhook_configured);
     const callerId = voiceNumber ? voiceNumber.phone_number : null;
 
-    // Check if this is an outgoing call from browser
-    if (req.body.To) {
+    // Check if this is an outgoing call from browser (From will be "client:browser_user")
+    if (req.body.From && req.body.From.startsWith('client:')) {
       // Outgoing call from browser to external number
       const dial = response.dial({
-        callerId: callerId || req.body.To
+        callerId: callerId
       });
       dial.number(req.body.To);
     } else {


### PR DESCRIPTION
Issue:
When calling the Twilio number from a cell phone, the browser app never rang. Twilio logs showed calls as "busy".

Root Cause:
The /voice webhook logic was broken. It checked:
  if (req.body.To) { /* treat as outgoing */ }

But req.body.To ALWAYS exists for both incoming and outgoing calls:
- Incoming: To = Twilio number, From = caller's cell phone
- Outgoing from browser: To = external number, From = "client:browser_user"

So ALL calls were being treated as outgoing, causing incoming calls to fail.

The Fix:
Changed the detection logic to check req.body.From:
  if (req.body.From && req.body.From.startsWith('client:')) {
    // Outgoing call from browser
  } else {
    // Incoming call - route to browser
  }

Now it correctly:
- Detects outgoing calls when From="client:browser_user"
- Routes incoming calls to the browser client when From is a phone number

Changes:
- api/index.js /voice webhook:
  - Fixed incoming vs outgoing call detection
  - Uses From field instead of To field
  - Properly routes incoming calls to browser_user client

Incoming calls should now ring in the browser app correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)