### PR TITLE
Make SMS wizard smarter - detect existing credentials from voice setup

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -294,12 +294,33 @@ app.post('/api/setup/sms/complete', async (req, res) => {
   try {
     const { accountSid, authToken } = req.body;
 
-    if (!accountSid || !authToken) {
-      return res.status(400).json({ error: 'Missing required fields' });
+    // Check if account already exists (from voice setup)
+    let account = await kv.get('twilio_account');
+
+    // If no account exists, credentials are required
+    if (!account) {
+      if (!accountSid || !authToken) {
+        return res.status(400).json({ error: 'Missing required fields' });
+      }
+
+      // Validate credentials by making a test API call
+      const client = twilio(accountSid, authToken);
+      try {
+        await client.api.accounts(accountSid).fetch();
+      } catch (error) {
+        return res.status(401).json({ error: 'Invalid Twilio credentials' });
+      }
+
+      // Create new account entry
+      account = {
+        accountSid,
+        authToken,
+        voice_setup_completed: false,
+        created_at: new Date().toISOString()
+      };
     }
 
-    // Update account to mark SMS setup as completed
-    const account = await kv.get('twilio_account');
+    // Mark SMS as completed
     await kv.set('twilio_account', {
       ...account,
       sms_setup_completed: true

--- a/public/sms-setup.html
+++ b/public/sms-setup.html
@@ -297,6 +297,38 @@
         let currentStep = 1;
         let credentials = {};
 
+        // Check if credentials already exist on page load
+        async function checkExistingCredentials() {
+            try {
+                const response = await fetch('/api/status');
+                const data = await response.json();
+
+                // If account is already configured with credentials, skip credential step
+                if (data.account_configured) {
+                    // Show loading message
+                    document.getElementById('step1-message').innerHTML =
+                        '<div class="status-message info">Credentials already configured. Proceeding to SMS setup...</div>';
+
+                    // Disable inputs since we're auto-proceeding
+                    document.getElementById('accountSid').disabled = true;
+                    document.getElementById('authToken').disabled = true;
+
+                    // Wait a moment then go to step 2
+                    setTimeout(() => {
+                        // We have credentials, go directly to completion
+                        credentials = { hasExisting: true };
+                        goToStep(2);
+                    }, 1000);
+                }
+            } catch (error) {
+                console.error('Failed to check credentials:', error);
+                // Continue showing credential form on error
+            }
+        }
+
+        // Run check on page load
+        checkExistingCredentials();
+
         function goToStep(step) {
             // Hide all steps
             document.querySelectorAll('.wizard-step').forEach(el => el.classList.remove('active'));
@@ -358,13 +390,18 @@
             try {
                 statusDiv.innerHTML = '<p>⏳ Enabling SMS features...</p>';
 
+                // If using existing credentials, send empty object (backend will use existing account)
+                const requestBody = credentials.hasExisting
+                    ? {}
+                    : {
+                        accountSid: credentials.accountSid,
+                        authToken: credentials.authToken
+                    };
+
                 const response = await fetch('/api/setup/sms/complete', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        accountSid: credentials.accountSid,
-                        authToken: credentials.authToken
-                    })
+                    body: JSON.stringify(requestBody)
                 });
 
                 const data = await response.json();


### PR DESCRIPTION
Issue:
When user completes voice wizard (enters credentials) and then goes to SMS wizard, they were asked to enter credentials again. Poor UX - should detect credentials already exist and skip that step.

The Fix:

Frontend (public/sms-setup.html):
- Added checkExistingCredentials() function that runs on page load
- Calls /api/status to check if account_configured is true
- If credentials exist:
  - Shows message: "Credentials already configured. Proceeding to SMS setup..."
  - Disables credential input fields
  - Auto-advances to step 2 after 1 second
  - Sets credentials.hasExisting flag
- If no credentials, shows normal credential entry form

- Updated completeSMSSetup() to send empty request body when using existing credentials
  - Backend detects existing account and uses those credentials
  - Only sends accountSid/authToken if user entered them manually

Backend (api/index.js):
- Updated POST /api/setup/sms/complete to be smarter:
  - First checks if twilio_account exists in KV
  - If account exists: Uses existing credentials, just marks SMS as completed
  - If no account: Requires credentials in request, validates them, creates account
  - This supports both flows:
    1. Voice setup first (credentials exist) → SMS wizard skips credential entry
    2. SMS setup first (no voice yet) → SMS wizard requires credential entry

Benefits:
- Seamless UX when doing voice → SMS setup
- Still works if user does SMS first
- No duplicate credential entry
- Clear messaging about what's happening
- Credentials validated once, reused everywhere

User Flow Now:
1. Complete voice wizard (enter credentials once)
2. Click "Configure SMS" on setup page
3. SMS wizard detects existing credentials
4. Shows "Credentials already configured" message
5. Auto-proceeds to completion step
6. Done in ~2 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)