### PR TITLE
Make voice wizard smarter - detect existing credentials from SMS setup

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -243,10 +243,36 @@ app.post('/api/setup/voice/credentials', async (req, res) => {
 // Voice Setup: Complete configuration
 app.post('/api/setup/voice/complete', async (req, res) => {
   try {
-    const { accountSid, authToken } = req.body;
+    let { accountSid, authToken } = req.body;
 
-    if (!accountSid || !authToken) {
-      return res.status(400).json({ error: 'Missing required fields' });
+    // Check if account already exists (from SMS setup)
+    let account = await kv.get('twilio_account');
+
+    // If account exists, use those credentials
+    if (account && account.accountSid && account.authToken) {
+      accountSid = account.accountSid;
+      authToken = account.authToken;
+    } else {
+      // No existing account, credentials are required
+      if (!accountSid || !authToken) {
+        return res.status(400).json({ error: 'Missing required fields' });
+      }
+
+      // Validate credentials by making a test API call
+      const client = twilio(accountSid, authToken);
+      try {
+        await client.api.accounts(accountSid).fetch();
+      } catch (error) {
+        return res.status(401).json({ error: 'Invalid Twilio credentials' });
+      }
+
+      // Create new account entry if doesn't exist
+      account = {
+        accountSid,
+        authToken,
+        sms_setup_completed: false,
+        created_at: new Date().toISOString()
+      };
     }
 
     const protocol = req.headers['x-forwarded-proto'] || 'https';
@@ -272,7 +298,6 @@ app.post('/api/setup/voice/complete', async (req, res) => {
     });
 
     // Update account to mark voice setup as completed
-    const account = await kv.get('twilio_account');
     await kv.set('twilio_account', {
       ...account,
       voice_setup_completed: true

--- a/public/voice-setup.html
+++ b/public/voice-setup.html
@@ -304,6 +304,38 @@
         let currentStep = 1;
         let credentials = {};
 
+        // Check if credentials already exist on page load
+        async function checkExistingCredentials() {
+            try {
+                const response = await fetch('/api/status');
+                const data = await response.json();
+
+                // If account is already configured with credentials, skip credential step
+                if (data.account_configured) {
+                    // Show loading message
+                    document.getElementById('step1-message').innerHTML =
+                        '<div class="status-message info">Credentials already configured. Proceeding to voice setup...</div>';
+
+                    // Disable inputs since we're auto-proceeding
+                    document.getElementById('accountSid').disabled = true;
+                    document.getElementById('authToken').disabled = true;
+
+                    // Wait a moment then go to step 2
+                    setTimeout(() => {
+                        // We have credentials, go directly to configuration
+                        credentials = { hasExisting: true };
+                        goToStep(2);
+                    }, 1000);
+                }
+            } catch (error) {
+                console.error('Failed to check credentials:', error);
+                // Continue showing credential form on error
+            }
+        }
+
+        // Run check on page load
+        checkExistingCredentials();
+
         function goToStep(step) {
             // Hide all steps
             document.querySelectorAll('.wizard-step').forEach(el => el.classList.remove('active'));
@@ -368,13 +400,18 @@
                     <p>⏳ Generating API Keys...</p>
                 `;
 
+                // If using existing credentials, send empty object (backend will use existing account)
+                const requestBody = credentials.hasExisting
+                    ? {}
+                    : {
+                        accountSid: credentials.accountSid,
+                        authToken: credentials.authToken
+                    };
+
                 const response = await fetch('/api/setup/voice/complete', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        accountSid: credentials.accountSid,
-                        authToken: credentials.authToken
-                    })
+                    body: JSON.stringify(requestBody)
                 });
 
                 const data = await response.json();


### PR DESCRIPTION
Issue:
Voice wizard always asked for credentials, even if user already entered them during SMS setup. This creates duplicate work and poor UX.

The Fix:

Frontend (public/voice-setup.html):
- Added checkExistingCredentials() that runs on page load
- Calls /api/status to check if account_configured is true
- If credentials exist:
  - Shows "Credentials already configured. Proceeding to voice setup..."
  - Disables credential input fields
  - Auto-advances to step 2 after 1 second
  - Sets credentials.hasExisting flag
- Updated configureVoice() to send empty body when using existing credentials

Backend (api/index.js):
- Updated POST /api/setup/voice/complete to detect existing account:
  - Checks if twilio_account exists in KV with credentials
  - If exists: Uses those credentials for TwiML provisioning
  - If not exists: Requires credentials in request, validates them
  - Supports both SMS-first and Voice-first setup flows
  - Validates credentials via Twilio API call before accepting

Benefits:
- Both wizards now detect existing credentials
- No duplicate credential entry regardless of order
- Works for: Voice→SMS, SMS→Voice, Voice-only, or SMS-only
- Consistent UX across both wizards
- Clear messaging about what's happening

User Flows:
1. Voice → SMS: Enter creds once, SMS skips creds
2. SMS → Voice: Enter creds once, Voice skips creds
3. Voice only: Enter creds normally
4. SMS only: Enter creds normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)