### PR TITLE
Add ADMIN_EMAIL to production environment

### DIFF
--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -83,6 +83,8 @@ bucket_name = "customer-service-media"
 # Environment variables (production)
 [env.production.vars]
 ENVIRONMENT = "production"
+FRONTEND_URL = "https://claude-wootestnew.pages.dev"
+ADMIN_EMAIL = "dev@woophone.io"
 
 # Durable Objects (production)
 [[env.production.durable_objects.bindings]]


### PR DESCRIPTION
This enables admin access for dev@woophone.io in production. Previously only staging had this configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)