### PR TITLE
Fix health check to use updated credentials after auto-fix

### DIFF
--- a/backend/src/api/providers/fix.js
+++ b/backend/src/api/providers/fix.js
@@ -126,10 +126,19 @@ app.post('/', async (c) => {
       prisma
     );
 
-    // Step 3: Run health check again to confirm fixes
+    // Step 3: Re-fetch provider to get updated credentials
+    console.log('[Auto-Fix API] Re-fetching provider with updated credentials...');
+    const updatedProvider = await prisma.provider.findFirst({
+      where: {
+        id: providerId,
+        companyId: companyId,
+      },
+    });
+
+    // Step 4: Run health check again with updated provider to confirm fixes
     console.log('[Auto-Fix API] Running post-fix health check...');
     const postFixHealthResults = await runFullHealthCheck(
-      provider,
+      updatedProvider,
       channels,
       baseUrl,
       c.env.ENCRYPTION_KEY


### PR DESCRIPTION
The post-fix health check was using the old cached provider object, showing stale results even after credentials were successfully updated.

Now re-fetches provider from database after fixes complete.