### PR TITLE
Add delay after credential update for Twilio API Key activation

### DIFF
--- a/backend/src/api/providers/fix.js
+++ b/backend/src/api/providers/fix.js
@@ -135,7 +135,13 @@ app.post('/', async (c) => {
       },
     });
 
-    // Step 4: Run health check again with updated provider to confirm fixes
+    // Step 4: Wait a moment for Twilio to activate new credentials
+    if (fixResults.credentialsUpdated) {
+      console.log('[Auto-Fix API] Credentials were updated, waiting 3 seconds for Twilio activation...');
+      await new Promise(resolve => setTimeout(resolve, 3000));
+    }
+
+    // Step 5: Run health check again with updated provider to confirm fixes
     console.log('[Auto-Fix API] Running post-fix health check...');
     const postFixHealthResults = await runFullHealthCheck(
       updatedProvider,


### PR DESCRIPTION
Twilio needs a few seconds to activate newly created API Keys. Without this delay, the immediate post-fix health check fails even though the credentials are valid and calling works.

Adds 3 second delay after credential updates before verification.