### PR TITLE
Fix modal health check to use post-fix results from API

### DIFF
--- a/frontend/src/components/modals/HealthCheckModal.jsx
+++ b/frontend/src/components/modals/HealthCheckModal.jsx
@@ -47,8 +47,17 @@ export default function HealthCheckModal({ isOpen, onClose, provider, onFixed })
       if (response.data.success) {
         const fixData = response.data.data;
 
-        // Run health check again to show updated status
-        await runHealthCheck();
+        // IMPORTANT: Use the afterHealth result from the fix API response
+        // The fix API already ran a health check after waiting for credentials to activate
+        // Running our own health check immediately would be too soon
+        if (fixData.afterHealth) {
+          console.log('[HealthCheckModal] Using post-fix health check from API response');
+          setHealthResults(fixData.afterHealth);
+        } else {
+          // Fallback: Run health check again if afterHealth is not available
+          console.warn('[HealthCheckModal] No afterHealth in response, running manual check');
+          await runHealthCheck();
+        }
 
         // Notify parent if any fixes were made
         if (Object.keys(fixData.fixed).length > 0) {


### PR DESCRIPTION
The modal was ignoring the afterHealth result from the fix API and immediately running its own health check without delay. This caused false failures because the check ran before Twilio API keys were fully activated.

The fix API already:
- Updates credentials in database
- Waits 3 seconds for Twilio activation
- Runs post-fix health check with proper timing

Now the modal uses those results instead of making a premature check.

Fixes issue where modal showed API Key errors even though auto-fix created valid credentials and calling worked on dashboard.