### PR TITLE
Add comprehensive logging to trace API Key flow through auto-fix

### DIFF
--- a/backend/src/api/providers/fix.js
+++ b/backend/src/api/providers/fix.js
@@ -135,6 +135,20 @@ app.post('/', async (c) => {
       },
     });
 
+    // Decrypt and log what credentials we re-fetched
+    const { decryptCredentials } = await import('../../lib/encryption.js');
+    const refetchedCreds = await decryptCredentials(
+      updatedProvider.credentials,
+      c.env.ENCRYPTION_KEY
+    );
+    console.log('[Auto-Fix API] ✓ Re-fetched provider credentials from database:', {
+      accountSid: refetchedCreds.accountSid,
+      apiKeySid: refetchedCreds.apiKeySid,
+      twimlAppSid: refetchedCreds.twimlAppSid,
+      hasAuthToken: !!refetchedCreds.authToken,
+      hasApiKeySecret: !!refetchedCreds.apiKeySecret,
+    });
+
     // Step 4: Wait a moment for Twilio to activate new credentials
     if (fixResults.credentialsUpdated) {
       console.log('[Auto-Fix API] Credentials were updated, waiting 3 seconds for Twilio activation...');

--- a/backend/src/lib/twilio-fix.js
+++ b/backend/src/lib/twilio-fix.js
@@ -103,6 +103,11 @@ export async function fixAPIKey(accountSid, authToken, companyName) {
 
     const newKey = await createTwilioAPIKey(accountSid, authToken, friendlyName);
 
+    console.log('[Auto-Fix] ✓ Created API Key in Twilio:', {
+      sid: newKey.sid,
+      friendlyName: friendlyName,
+    });
+
     return {
       success: true,
       apiKeySid: newKey.sid,
@@ -342,6 +347,11 @@ export async function fixAll(
       updatedCredentials.apiKeySid = apiKeyFix.apiKeySid;
       updatedCredentials.apiKeySecret = apiKeyFix.apiKeySecret;
       needsCredentialUpdate = true;
+
+      console.log('[Auto-Fix] ✓ Updated credentials object with new API Key:', {
+        apiKeySid: apiKeyFix.apiKeySid,
+        willSaveToDatabase: true,
+      });
     } else {
       results.cantFix.apiKey = apiKeyFix.message;
     }
@@ -402,6 +412,14 @@ export async function fixAll(
   // Update credentials in database if needed
   if (needsCredentialUpdate) {
     console.log('[Auto-Fix] Credentials were updated, saving to database...');
+    console.log('[Auto-Fix] Saving credentials:', {
+      accountSid: updatedCredentials.accountSid,
+      apiKeySid: updatedCredentials.apiKeySid,
+      twimlAppSid: updatedCredentials.twimlAppSid,
+      hasAuthToken: !!updatedCredentials.authToken,
+      hasApiKeySecret: !!updatedCredentials.apiKeySecret,
+    });
+
     const credentialUpdate = await updateProviderCredentials(
       prisma,
       provider.id,
@@ -411,7 +429,7 @@ export async function fixAll(
 
     if (credentialUpdate.success) {
       results.credentialsUpdated = true;
-      console.log('[Auto-Fix] Credentials updated successfully');
+      console.log('[Auto-Fix] ✓ Credentials saved to database successfully');
     } else {
       results.cantFix.credentialUpdate = credentialUpdate.message;
     }

--- a/backend/src/lib/twilio-health.js
+++ b/backend/src/lib/twilio-health.js
@@ -157,6 +157,7 @@ export async function checkTwiMLApp(client, twimlAppSid, expectedBaseUrl) {
 export async function checkAPIKey(accountSid, apiKeySid, apiKeySecret, twimlAppSid) {
   try {
     console.log('[Health Check] Testing API Key by verifying it exists in Twilio...');
+    console.log('[Health Check] Checking API Key SID:', apiKeySid);
 
     const twilio = await import('twilio');
 
@@ -169,9 +170,11 @@ export async function checkAPIKey(accountSid, apiKeySid, apiKeySecret, twimlAppS
     // Try to make a simple API call to verify the credentials work
     try {
       await client.api.v2010.accounts(accountSid).fetch();
+      console.log('[Health Check] ✓ API Key authenticated successfully with Twilio');
     } catch (authError) {
       // If we get an authentication error, the API Key doesn't exist or is invalid
-      console.error('[Health Check] API Key authentication failed:', authError.message);
+      console.error('[Health Check] ✗ API Key authentication failed:', authError.message);
+      console.error('[Health Check] Failed API Key SID:', apiKeySid);
       return {
         status: 'fail',
         message: 'API Key does not exist in Twilio or is invalid',
@@ -380,6 +383,8 @@ export async function checkPhoneNumber(
  */
 export async function runFullHealthCheck(provider, channels, baseUrl, encryptionKey) {
   console.log('[Health Check] Starting full health check...');
+  console.log('[Health Check] Provider ID:', provider.id);
+  console.log('[Health Check] Provider last updated:', provider.updatedAt);
 
   const results = {
     overall: 'healthy',
@@ -395,6 +400,14 @@ export async function runFullHealthCheck(provider, channels, baseUrl, encryption
   try {
     // Decrypt credentials
     const credentials = await decryptCredentials(provider.credentials, encryptionKey);
+
+    console.log('[Health Check] Decrypted credentials:', {
+      accountSid: credentials.accountSid,
+      apiKeySid: credentials.apiKeySid,
+      twimlAppSid: credentials.twimlAppSid,
+      hasAuthToken: !!credentials.authToken,
+      hasApiKeySecret: !!credentials.apiKeySecret,
+    });
 
     // Check 1: Credentials
     console.log('[Health Check] Checking credentials...');


### PR DESCRIPTION
Added detailed logging at every step to diagnose why health check shows API Key errors when dashboard calling works:

1. Auto-fix creates API Key - logs new SID created in Twilio
2. Auto-fix updates credentials object - logs API Key SID being set
3. Auto-fix saves to database - logs all credentials being saved
4. Fix API re-fetches provider - logs credentials retrieved from DB
5. Health check starts - logs provider details and decrypted credentials
6. Health check checks API Key - logs exact SID being tested
7. Dashboard token generation - already logs API Key SID used

This will reveal exactly where the mismatch occurs when:
- Auto-fix creates valid API Key (confirmed in Twilio console)
- Dashboard calling works (confirmed by user)
- But health check says "API Key does not exist in Twilio or is invalid"

The logs will show if health check is:
- Checking old/stale API Key SID
- Not receiving updated credentials from database
- Timing issue with re-fetch or decryption