### PR TITLE
Move Settings pages inside DashboardLayout to show sidebar and call w…

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -92,16 +92,16 @@ function App() {
         <Route path="/contacts" element={<ContactsPage />} />
         <Route path="/calls" element={<CallHistoryPage />} />
         <Route path="/conversations" element={<ConversationsPage />} />
-      </Route>
 
-      {/* Settings routes - each is independent with unique keys to force remounting */}
-      <Route path="/settings" element={<Navigate to="/settings/providers" replace />} />
-      <Route path="/settings/providers" element={<ProtectedRoute key="providers"><ProvidersPage key="providers-page" /></ProtectedRoute>} />
-      <Route path="/settings/channels" element={<ProtectedRoute key="channels"><ChannelsPage key="channels-page" /></ProtectedRoute>} />
-      <Route path="/settings/inboxes" element={<ProtectedRoute key="inboxes"><InboxesPage key="inboxes-page" /></ProtectedRoute>} />
-      <Route path="/settings/company" element={<ProtectedRoute key="company"><CompanyPage key="company-page" /></ProtectedRoute>} />
-      <Route path="/settings/team" element={<ProtectedRoute key="team"><TeamPage key="team-page" /></ProtectedRoute>} />
-      <Route path="/settings/profile" element={<ProtectedRoute key="profile"><ProfilePage key="profile-page" /></ProtectedRoute>} />
+        {/* Settings routes - now inside DashboardLayout to show sidebar and call widget */}
+        <Route path="/settings" element={<Navigate to="/settings/providers" replace />} />
+        <Route path="/settings/providers" element={<ProvidersPage key="providers-page" />} />
+        <Route path="/settings/channels" element={<ChannelsPage key="channels-page" />} />
+        <Route path="/settings/inboxes" element={<InboxesPage key="inboxes-page" />} />
+        <Route path="/settings/company" element={<CompanyPage key="company-page" />} />
+        <Route path="/settings/team" element={<TeamPage key="team-page" />} />
+        <Route path="/settings/profile" element={<ProfilePage key="profile-page" />} />
+      </Route>
 
       {/* Debug routes */}
       <Route path="/debug/twilio" element={<ProtectedRoute><DebugTwilio /></ProtectedRoute>} />

--- a/frontend/src/layouts/DashboardLayout.jsx
+++ b/frontend/src/layouts/DashboardLayout.jsx
@@ -43,7 +43,13 @@ function DashboardLayout() {
     { path: '/settings', label: 'Settings', icon: Settings },
   ];
 
-  const isActive = (path) => location.pathname === path;
+  const isActive = (path) => {
+    // For settings, highlight if we're on any settings sub-route
+    if (path === '/settings') {
+      return location.pathname.startsWith('/settings');
+    }
+    return location.pathname === path;
+  };
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex">

--- a/frontend/src/pages/settings/SettingsLayout.jsx
+++ b/frontend/src/pages/settings/SettingsLayout.jsx
@@ -25,8 +25,8 @@ function SettingsLayout({ children }) {
   ];
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <div className="p-8">
+      <div className="max-w-7xl mx-auto">
         <div className="mb-8">
           <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Settings</h1>
           <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">


### PR DESCRIPTION
…idget

Changes:
1. Moved all Settings routes inside DashboardLayout wrapper in App.jsx
   - Settings now shares the same layout as Dashboard/Contacts/Calls/Conversations
   - Main left sidebar (Dashboard, Contacts, etc.) now visible on Settings pages
   - CallManager (floating call widget) now visible on Settings pages

2. Updated SettingsLayout to remove full-page styling
   - Removed min-h-screen and bg-gray-50 since it's now nested inside DashboardLayout
   - SettingsLayout now just renders its content area with settings sub-navigation

3. Fixed Settings highlighting in main sidebar
   - Settings now highlights when on any /settings/* sub-route
   - Uses startsWith('/settings') instead of exact match

Result: Settings pages now have consistent navigation with rest of app, keeping the main sidebar and call widget always visible.