### PR TITLE
Add comprehensive Device Status investigation report

### DIFF
--- a/DEVICE_STATUS_INVESTIGATION_REPORT.md
+++ b/DEVICE_STATUS_INVESTIGATION_REPORT.md
@@ -1,0 +1,414 @@
+# Device Status Investigation Report
+**Date:** 2025-11-08
+**Component:** Twilio Device Status Indicator (Top-Right Corner UI)
+
+---
+
+## Executive Summary
+
+The green "Ready to receive calls" vs red "Calling unavailable, Device disconnected" indicator in the top-right corner is determined by the Twilio Device registration status. This report documents the complete flow from page load to status display, all validation checks performed, and all failure points.
+
+---
+
+## Visual Indicators
+
+### 🟢 Green (Success)
+```
+Ready to receive calls
+You can now answer incoming calls
+```
+**Meaning:** Twilio Device successfully registered and ready for calls
+**Auto-hide:** Disappears after 3 seconds
+**Location:** `DeviceStatus.jsx:82-94`
+
+### 🔴 Red (Error)
+```
+Calling unavailable
+{error message}
+Refresh to try again
+```
+**Meaning:** Twilio Device failed to initialize or disconnected
+**Auto-hide:** Stays visible until resolved
+**Location:** `DeviceStatus.jsx:96-114`
+
+### 🟡 Yellow (Initializing)
+```
+Initializing calling...
+Setting up Twilio Device
+```
+**Meaning:** Currently fetching token and registering device
+**Location:** `DeviceStatus.jsx:68-80`
+
+---
+
+## Complete Initialization Flow
+
+### Step 1: Component Mount
+**File:** `layouts/DashboardLayout.jsx:27-136`
+
+When user loads Dashboard/Contacts/Calls/Conversations/Settings:
+1. `DashboardLayout` renders
+2. Includes `<CallManager />` component (line 135)
+3. Includes `<DeviceStatus />` component (line 132)
+
+Both components mount and initialize in parallel.
+
+---
+
+### Step 2: Device Initialization Request
+**File:** `components/calls/CallManager.jsx:136-159`
+
+```javascript
+const initializeDevice = async () => {
+  await twilioDevice.initialize();  // Calls token endpoint
+  setDeviceReady(true);
+  twilioDevice.on('incoming', handleIncomingCall);
+  twilioDevice.on('error', handleError);
+}
+```
+
+**Triggers:** `services/twilio-device.js:41-91`
+
+---
+
+### Step 3: Backend Token Generation
+**File:** `backend/src/api/voice/index.js:27-124`
+
+**Request:** `POST /api/v1/voice/token`
+
+**Validation Checks (in order):**
+
+#### ✓ Check 1: User Exists
+```javascript
+const user = await prisma.user.findUnique({
+  where: { id: userId }
+});
+if (!user) return PROVIDER_NOT_FOUND (404)
+```
+**Failure:** User not in database → 404 error
+
+#### ✓ Check 2: Active Twilio Provider Exists
+```javascript
+const provider = await prisma.provider.findFirst({
+  where: {
+    companyId: companyId,
+    type: 'TWILIO',
+    status: 'ACTIVE'
+  }
+});
+if (!provider) return PROVIDER_NOT_FOUND (404)
+```
+**Failure:** No Twilio provider configured → 404 error → DeviceStatus hides
+
+#### ✓ Check 3: Decrypt Credentials
+```javascript
+const credentials = await decryptCredentials(
+  provider.credentials,
+  c.env.ENCRYPTION_KEY
+);
+```
+**Failure:** Decryption fails → 500 error
+
+#### ✓ Check 4: Generate JWT Token
+**File:** `backend/src/lib/twilio.js:230-265`
+
+```javascript
+const token = new AccessToken(
+  credentials.accountSid,    // From database
+  credentials.apiKeySid,     // From database
+  credentials.apiKeySecret,  // From database
+  { identity: userId, ttl: 3600 }
+);
+
+const voiceGrant = new VoiceGrant({
+  outgoingApplicationSid: credentials.twimlAppSid,  // From database
+  incomingAllow: true
+});
+
+token.addGrant(voiceGrant);
+return token.toJwt();
+```
+
+**Critical:** This uses credentials from database. If auto-fix updated the database with new API Key, this will use the NEW API Key.
+
+**Failure:** Token generation throws error → 500 error
+
+---
+
+### Step 4: Frontend Device Registration
+**File:** `services/twilio-device.js:41-91`
+
+```javascript
+// Create Device with token from backend
+this.device = new Device(token, {
+  logLevel: 'debug',
+  edge: 'ashburn'
+});
+
+this.setupEventListeners();
+
+// Register device with Twilio
+await this.device.register();
+```
+
+**Validation by Twilio:**
+1. **JWT Signature:** Twilio validates JWT was signed with valid API Key
+2. **API Key Exists:** Twilio checks if `apiKeySid` exists in account
+3. **API Key Active:** Twilio checks if API Key is not deleted/revoked
+4. **Account SID Match:** Twilio checks if API Key belongs to Account SID
+5. **TwiML App Exists:** Twilio checks if `twimlAppSid` exists in account
+
+**Success:** Device state becomes 'registered' → Triggers 'registered' event
+
+**Failure Examples:**
+- `AccessTokenInvalid (20101)` → API Key doesn't exist or is invalid
+- `JWT is invalid` → API Key was deleted or credentials don't match
+
+---
+
+### Step 5: Status Display
+**File:** `components/calls/DeviceStatus.jsx:16-119`
+
+**Event Listeners:**
+
+#### Event: 'registered'
+```javascript
+twilioDevice.on('registered', () => {
+  setStatus('ready');  // 🟢 Green indicator
+  setTimeout(() => setShowIndicator(false), 3000);  // Auto-hide
+});
+```
+
+#### Event: 'error'
+```javascript
+twilioDevice.on('error', (err) => {
+  setStatus('error');  // 🔴 Red indicator
+  setError(err.message || 'Failed to initialize calling');
+});
+```
+
+#### Event: 'unregistered'
+```javascript
+twilioDevice.on('unregistered', () => {
+  setStatus('error');  // 🔴 Red indicator
+  setError('Device disconnected');
+  setShowIndicator(true);  // Force visible
+});
+```
+
+#### Event: 'no_provider'
+```javascript
+twilioDevice.on('no_provider', () => {
+  setShowIndicator(false);  // Hide indicator entirely
+});
+```
+
+---
+
+## Common Failure Scenarios
+
+### Scenario 1: No Twilio Provider Configured
+**Flow:**
+1. User has no Twilio connected
+2. Backend returns `PROVIDER_NOT_FOUND`
+3. Frontend triggers 'no_provider' event
+4. **Result:** Indicator hidden (no green or red shown)
+
+**User Experience:** Calling features silently disabled
+
+---
+
+### Scenario 2: Invalid/Deleted API Key
+**Flow:**
+1. Provider exists in database
+2. Database has `apiKeySid: SKold123...` (old/deleted)
+3. Backend generates JWT with old API Key
+4. Twilio rejects registration with `AccessTokenInvalid (20101)`
+5. Device triggers 'error' event
+6. **Result:** 🔴 Red "Calling unavailable, AccessTokenInvalid (20101)"
+
+**User Experience:** Red error shown
+
+---
+
+### Scenario 3: TwiML App Deleted
+**Flow:**
+1. Provider exists, API Key valid
+2. Database has `twimlAppSid: APold123...` (deleted)
+3. Backend generates JWT with deleted TwiML App
+4. Twilio rejects registration
+5. Device triggers 'error' event
+6. **Result:** 🔴 Red "Calling unavailable"
+
+**User Experience:** Red error shown
+
+---
+
+### Scenario 4: Network Disconnection
+**Flow:**
+1. Device was registered successfully (green shown)
+2. User's network drops or app backgrounded
+3. Twilio WebSocket closes
+4. Device state changes to 'unregistered'
+5. Device triggers 'unregistered' event
+6. **Result:** 🔴 Red "Device disconnected"
+
+**User Experience:** Red error appears, prompts refresh
+
+**Recovery:** `CallManager.jsx:36-58` handles visibilitychange to auto-reconnect
+
+---
+
+### Scenario 5: Valid Credentials (Success)
+**Flow:**
+1. Provider exists in database
+2. Credentials valid: accountSid, apiKeySid (exists in Twilio), apiKeySecret (correct), twimlAppSid (exists)
+3. Backend generates valid JWT
+4. Twilio accepts registration
+5. Device state becomes 'registered'
+6. Device triggers 'registered' event
+7. **Result:** 🟢 Green "Ready to receive calls" (auto-hides after 3s)
+
+**User Experience:** Brief green confirmation, then disappears
+
+---
+
+## The Health Check vs Dashboard Discrepancy
+
+### Current Issue
+**User Reports:**
+- Health Check (Settings): Shows "API Key does not exist in Twilio or is invalid" (red)
+- Dashboard: Shows "Ready to receive calls" (green)
+- Twilio Console: Shows new API Key exists (SKc97666ee80f5243a511a322b3c51a097)
+
+### Root Cause Analysis
+
+**Dashboard Token Generation** (`backend/src/api/voice/index.js:78-102`):
+```javascript
+// Get provider from database
+const provider = await prisma.provider.findFirst({
+  where: { companyId, type: 'TWILIO', status: 'ACTIVE' }
+});
+
+// Decrypt credentials
+const credentials = await decryptCredentials(provider.credentials);
+
+// credentials.apiKeySid = NEW API Key (SKc976...)
+```
+✅ **Uses fresh database query** → Gets updated API Key → Token works → Green status
+
+**Health Check** (`backend/src/api/providers/fix.js:129-150`):
+```javascript
+// Step 3: Re-fetch provider with updated credentials
+const updatedProvider = await prisma.provider.findFirst({
+  where: { id: providerId, companyId: companyId }
+});
+
+// Step 5: Run health check
+const postFixHealthResults = await runFullHealthCheck(
+  updatedProvider, channels, baseUrl, encryptionKey
+);
+```
+
+**Health Check Execution** (`backend/src/lib/twilio-health.js:384-445`):
+```javascript
+// Decrypt credentials
+const credentials = await decryptCredentials(provider.credentials);
+
+// Check API Key
+const apiKeyCheck = await checkAPIKey(
+  credentials.accountSid,
+  credentials.apiKeySid,  // Using this from provider parameter
+  credentials.apiKeySecret,
+  credentials.twimlAppSid
+);
+```
+
+**Health check tested:** `SK2d3cedffa8fecee2d84efa0c1d1057bb` (OLD)
+**Auto-fix created:** `SKc97666ee80f5243a511a322b3c51a097` (NEW)
+**Dashboard using:** `SKc97666ee80f5243a511a322b3c51a097` (NEW)
+
+**Hypothesis:** The database update is either:
+1. Not executing (silent failure)
+2. Executing but not committing
+3. Committing but re-fetch getting cached/stale data
+4. Being overwritten between save and re-fetch
+
+**Next Step:** The logging added in latest commit will reveal exactly where the mismatch occurs.
+
+---
+
+## Dependency Chain
+
+```
+DashboardLayout
+  ├─> CallManager (component)
+  │     ├─> twilioDevice.initialize() (service)
+  │     │     └─> POST /api/v1/voice/token (backend)
+  │     │           ├─> Fetch user from DB
+  │     │           ├─> Fetch provider from DB
+  │     │           ├─> Decrypt credentials
+  │     │           └─> Generate JWT with credentials
+  │     ├─> twilioDevice.on('registered')
+  │     ├─> twilioDevice.on('error')
+  │     └─> twilioDevice.on('incoming')
+  │
+  └─> DeviceStatus (component)
+        ├─> twilioDevice.on('registered') → 🟢 Green
+        ├─> twilioDevice.on('error') → 🔴 Red
+        ├─> twilioDevice.on('unregistered') → 🔴 Red
+        └─> twilioDevice.on('no_provider') → Hide
+```
+
+---
+
+## Files Reference
+
+### Frontend
+- `layouts/DashboardLayout.jsx` - Mounts CallManager and DeviceStatus
+- `components/calls/CallManager.jsx` - Orchestrates device initialization
+- `components/calls/DeviceStatus.jsx` - Displays status indicator UI
+- `services/twilio-device.js` - Twilio Device service wrapper
+
+### Backend
+- `backend/src/api/voice/index.js` - Token generation endpoint
+- `backend/src/lib/twilio.js` - Twilio API helpers, JWT generation
+- `backend/src/lib/encryption.js` - Credential encryption/decryption
+- `backend/src/api/providers/health.js` - Health check endpoint
+- `backend/src/lib/twilio-health.js` - Health check validation logic
+
+---
+
+## Recommendations
+
+### For Debugging
+1. **Check Cloudflare logs** after clicking "Fix All" to see:
+   - `[Auto-Fix] ✓ Created API Key in Twilio: { sid: 'SKxxxx...' }`
+   - `[Auto-Fix] ✓ Verified saved credentials: { apiKeySid: 'SKxxxx...' }`
+   - `[Auto-Fix API] ✓ Re-fetched provider credentials: { apiKeySid: 'SKxxxx...' }`
+   - `[Health Check] Checking API Key SID: SKxxxx...`
+
+2. **Compare SIDs** at each step to find where mismatch occurs
+
+3. **Check database directly** to verify what's actually stored
+
+### For Production
+1. Add API Key validation before saving to database
+2. Add retry logic for database updates with verification
+3. Consider adding database transaction logging
+4. Add health check immediately after DB write to verify persistence
+
+---
+
+## Conclusion
+
+The device status indicator reliably reflects whether Twilio Device successfully registered. The green vs red status is determined by:
+
+1. ✅ **Provider exists** in database
+2. ✅ **Credentials are valid** (accountSid, authToken, apiKeySid, apiKeySecret, twimlAppSid)
+3. ✅ **API Key exists** in Twilio account (not deleted)
+4. ✅ **TwiML App exists** in Twilio account (not deleted)
+5. ✅ **JWT token validates** against Twilio's servers
+6. ✅ **Device registers** successfully
+
+Any failure in this chain results in red status. The current discrepancy between health check (red) and dashboard (green) indicates the health check is testing stale credentials while dashboard is using fresh credentials from database.


### PR DESCRIPTION
Documents complete flow from page load to status display:
- Green 'Ready to receive calls' success path
- Red 'Calling unavailable' failure scenarios
- All validation checks performed
- Complete dependency chain
- Root cause analysis of health check vs dashboard discrepancy

Report shows dashboard uses fresh DB credentials (new API Key works) but health check may be using stale data (old API Key fails).