### PR TITLE
Add database migration for message source tracking

### DIFF
--- a/backend/prisma/migrations/20251109162748_add_message_source_tracking/migration.sql
+++ b/backend/prisma/migrations/20251109162748_add_message_source_tracking/migration.sql
@@ -1,0 +1,9 @@
+-- CreateEnum
+-- Add MessageSource enum to track how messages entered the system
+CREATE TYPE "message_source" AS ENUM ('WEBHOOK', 'IMPORT', 'MANUAL', 'API');
+
+-- AlterTable
+-- Add source field to track message origin (defaults to WEBHOOK for backward compatibility)
+-- Add notificationSent field to track if push notification was sent
+ALTER TABLE "messages" ADD COLUMN "source" "message_source" NOT NULL DEFAULT 'WEBHOOK';
+ALTER TABLE "messages" ADD COLUMN "notification_sent" BOOLEAN NOT NULL DEFAULT false;


### PR DESCRIPTION
This migration adds:
- MessageSource enum (WEBHOOK, IMPORT, MANUAL, API)
- source column to messages table (defaults to WEBHOOK)
- notification_sent column to track push notification status

The migration will run automatically via CI/CD before deployment.