### PR TITLE
Add OneSignal secrets to deployment workflows

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -86,6 +86,8 @@ jobs:
           echo "${{ secrets.ENCRYPTION_KEY_PRODUCTION }}" | npx wrangler secret put ENCRYPTION_KEY --env production
           echo "${{ secrets.JWT_SECRET }}" | npx wrangler secret put JWT_SECRET --env production
           echo "${{ secrets.RESEND_API_KEY }}" | npx wrangler secret put RESEND_API_KEY --env production
+          echo "${{ secrets.ONESIGNAL_APP_ID }}" | npx wrangler secret put ONESIGNAL_APP_ID --env production
+          echo "${{ secrets.ONESIGNAL_REST_API_KEY }}" | npx wrangler secret put ONESIGNAL_REST_API_KEY --env production
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -76,6 +76,8 @@ jobs:
           echo "${{ secrets.ENCRYPTION_KEY_STAGING }}" | npx wrangler secret put ENCRYPTION_KEY --env staging
           echo "${{ secrets.JWT_SECRET }}" | npx wrangler secret put JWT_SECRET --env staging
           echo "${{ secrets.RESEND_API_KEY }}" | npx wrangler secret put RESEND_API_KEY --env staging
+          echo "${{ secrets.ONESIGNAL_APP_ID }}" | npx wrangler secret put ONESIGNAL_APP_ID --env staging
+          echo "${{ secrets.ONESIGNAL_REST_API_KEY }}" | npx wrangler secret put ONESIGNAL_REST_API_KEY --env staging
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 


### PR DESCRIPTION
Update both staging and production deployment workflows to automatically set ONESIGNAL_APP_ID and ONESIGNAL_REST_API_KEY secrets in Cloudflare Workers during deployment.

This completes the OneSignal notification setup - notifications will now be sent when real-time SMS messages arrive via webhook.