### PR TITLE
Fix notification UI issues

### DIFF
--- a/frontend/src/config/onesignal.js
+++ b/frontend/src/config/onesignal.js
@@ -102,12 +102,21 @@ export async function requestNotificationPermission(userId) {
 
 /**
  * Check if user is subscribed to push notifications
+ * Returns true only if permission is granted AND there's an active push subscription
  */
 export async function isSubscribed() {
   try {
     const OneSignal = await waitForOneSignal();
+
+    // Check if permission is granted
     const permission = await OneSignal.Notifications.permission;
-    return permission === 'granted';
+    if (permission !== 'granted') {
+      return false;
+    }
+
+    // Check if there's an active push subscription with a Player ID
+    const playerId = await OneSignal.User.PushSubscription.id;
+    return !!playerId;
   } catch (error) {
     console.error('[OneSignal] Failed to check subscription:', error);
     return false;

--- a/frontend/src/pages/settings/NotificationsPage.jsx
+++ b/frontend/src/pages/settings/NotificationsPage.jsx
@@ -80,7 +80,7 @@ function NotificationsPage() {
     setTestResult(null);
 
     try {
-      const response = await api.post('/notifications/test', { playerId });
+      const response = await api.post('/api/v1/notifications/test', { playerId });
       setTestResult({
         success: true,
         message: response.data.message || 'Test notification sent! Check your browser for the notification.'


### PR DESCRIPTION
1. Fix "Send Test Notification" 404 error:
   - Update API call to use correct path: /api/v1/notifications/test
   - Backend endpoint already existed, frontend was using wrong path

2. Fix subscription status not showing on page load:
   - Improve isSubscribed() to check for active Player ID
   - Now properly detects when user has granted permission AND has active subscription
   - Before: only checked if permission === 'granted'
   - After: checks permission AND verifies Player ID exists

These fixes ensure:
- Test notifications can be sent from the Notifications page
- Subscription status accurately reflects when user is subscribed
- UI shows correct state when returning to Notifications page