### PR TITLE
Fix test notification not being delivered

### DIFF
--- a/backend/src/api/notifications/index.js
+++ b/backend/src/api/notifications/index.js
@@ -63,9 +63,11 @@ app.post('/test', async (c) => {
     }
 
     // Send notification via OneSignal REST API
+    // For OneSignal SDK v16 (User Model), use include_subscription_ids instead of include_player_ids
     const notificationPayload = {
       app_id: appId,
-      include_player_ids: [playerId],
+      include_subscription_ids: [playerId],
+      target_channel: 'push',
       headings: { en: '🔔 Test Notification' },
       contents: { en: 'This is a test push notification from your Customer Service Platform!' },
       data: {
@@ -102,13 +104,18 @@ app.post('/test', async (c) => {
       );
     }
 
-    console.log('[Notifications] Test notification sent successfully:', result.id);
+    console.log('[Notifications] Test notification sent successfully:', {
+      notificationId: result.id,
+      recipients: result.recipients,
+      errors: result.errors,
+    });
 
     return c.json({
       success: true,
       message: 'Test notification sent successfully',
       notificationId: result.id,
       recipients: result.recipients,
+      ...(result.errors && { warnings: result.errors }),
     });
   } catch (error) {
     console.error('[Notifications] Error sending test notification:', error);


### PR DESCRIPTION
Issue: Test notifications returned success but weren't delivered to the browser.

Root Cause: Using wrong targeting method for OneSignal SDK v16 User Model
- Old approach: include_player_ids (Device Model - deprecated)
- Correct approach: include_subscription_ids (User Model)

Changes:
1. Updated test notification to use include_subscription_ids instead of include_player_ids
2. Added target_channel: 'push' to match real notification approach
3. Enhanced logging to show recipients and any errors/warnings

This aligns the test notification with how real notifications work (notification-service.js also uses User Model approach with external_id).

Result: Test notifications will now be delivered correctly to subscribed users.