### PR TITLE
Fix subscription status not persisting on page navigation

### DIFF
--- a/frontend/src/pages/settings/NotificationsPage.jsx
+++ b/frontend/src/pages/settings/NotificationsPage.jsx
@@ -32,17 +32,37 @@ function NotificationsPage() {
 
   async function checkSubscriptionStatus() {
     try {
+      console.log('[NotificationsPage] Checking subscription status for user:', user?.id);
+
+      // First, restore the OneSignal session by logging in with external_id
+      // This is necessary because the page might have reloaded and OneSignal needs to re-establish the user link
+      if (user?.id) {
+        const { loginUser } = await import('../../config/onesignal');
+        try {
+          await loginUser(user.id);
+          console.log('[NotificationsPage] OneSignal session restored with external_id:', user.id);
+        } catch (loginError) {
+          console.warn('[NotificationsPage] Could not restore OneSignal session:', loginError);
+          // Continue anyway - user might not be subscribed yet
+        }
+      }
+
+      // Small delay to let OneSignal fully initialize
+      await new Promise(resolve => setTimeout(resolve, 500));
+
       const subscribed = await isSubscribed();
+      console.log('[NotificationsPage] Subscription status:', subscribed);
       setSubscriptionStatus(subscribed ? 'subscribed' : 'not_subscribed');
 
       if (subscribed) {
         const id = await getPlayerId();
         const osId = await getOneSignalId();
+        console.log('[NotificationsPage] Player ID:', id, 'OneSignal ID:', osId);
         setPlayerId(id);
         setOneSignalId(osId);
       }
     } catch (error) {
-      console.error('Failed to check subscription status:', error);
+      console.error('[NotificationsPage] Failed to check subscription status:', error);
       setSubscriptionStatus('not_subscribed');
     }
   }


### PR DESCRIPTION
Issue: Notifications page always shows "Enable Notifications" button even when user is already subscribed. User has to click it every time they visit the page, creating terrible UX where they think notifications aren't enabled.

Root Cause: When page loads, OneSignal SDK doesn't automatically restore the external_id (user.id) linkage. Without calling OneSignal.login(userId), the SDK can't find the user's subscription even though it exists.

Fix:
1. Call loginUser(userId) during subscription check to restore session
2. Add 500ms delay to let OneSignal fully initialize before checking status
3. Add comprehensive logging to track subscription detection
4. Gracefully handle case where user isn't subscribed yet

Flow:
- User navigates to Notifications page
- checkSubscriptionStatus() runs on mount
- Restores OneSignal session with external_id
- Checks subscription status (permission + Player ID)
- Shows correct UI state (subscribed or not subscribed)

Result: Users who are already subscribed will see "Send Test Notification" button immediately without having to re-enable notifications every time.