### PR TITLE
Fix: Add missing X icon import causing white screen crash

### DIFF
--- a/frontend/src/pages/conversations/ConversationsPage.jsx
+++ b/frontend/src/pages/conversations/ConversationsPage.jsx
@@ -12,7 +12,7 @@
 
 import { useState, useEffect, useRef } from 'react';
 import { useInfiniteQuery, useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { MessageSquare, Send, User, Phone, Clock, MoreVertical, Trash2, Info, Check, CheckCheck, XCircle, AlertCircle, CheckCircle2, XOctagon, Loader2, Paperclip, RotateCw, Wifi, WifiOff } from 'lucide-react';
+import { MessageSquare, Send, User, Phone, Clock, MoreVertical, Trash2, Info, Check, CheckCheck, XCircle, AlertCircle, CheckCircle2, XOctagon, Loader2, Paperclip, RotateCw, Wifi, WifiOff, X } from 'lucide-react';
 import api from '../../services/api';
 import socketManager from '../../services/socket';
 import { useAuth } from '../../context/AuthContext';


### PR DESCRIPTION
When message send failed, the error UI tried to render an X close button but the icon wasn't imported, causing ReferenceError and white screen crash.

Changes:
- Added X icon to lucide-react imports

Impact: Error messages now display correctly without crashing the page

Fixes: ReferenceError: X is not defined at ConversationsPage.jsx:711