### PR TITLE
Fix: Add PENDING and UNDELIVERED to MessageStatus enum

### DIFF
--- a/backend/prisma/migrations/20251117000000_add_pending_undelivered_message_status/migration.sql
+++ b/backend/prisma/migrations/20251117000000_add_pending_undelivered_message_status/migration.sql
@@ -1,0 +1,8 @@
+-- AlterEnum: Add PENDING and UNDELIVERED to message_status enum
+-- This migration adds two new status values to support better message state tracking
+
+-- Add PENDING status (first in order, before SENT)
+ALTER TYPE "message_status" ADD VALUE 'PENDING';
+
+-- Add UNDELIVERED status (between DELIVERED and FAILED)
+ALTER TYPE "message_status" ADD VALUE 'UNDELIVERED';

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -397,10 +397,12 @@ enum SenderType {
 }
 
 enum MessageStatus {
-  SENT
-  DELIVERED
-  READ
-  FAILED
+  PENDING      // Message created, waiting for provider to accept
+  SENT         // Provider accepted, message is sending
+  DELIVERED    // Message successfully delivered to recipient
+  READ         // Message was read by recipient (if supported)
+  UNDELIVERED  // Provider could not deliver (temporary failure)
+  FAILED       // Message send failed permanently
 
   @@map("message_status")
 }

--- a/backend/src/webhooks/status.js
+++ b/backend/src/webhooks/status.js
@@ -275,7 +275,9 @@ app.post('/:channelId', async (c) => {
           let messageStatus = 'SENT';
           if (body.MessageStatus === 'delivered') {
             messageStatus = 'DELIVERED';
-          } else if (body.MessageStatus === 'failed' || body.MessageStatus === 'undelivered') {
+          } else if (body.MessageStatus === 'undelivered') {
+            messageStatus = 'UNDELIVERED';
+          } else if (body.MessageStatus === 'failed') {
             messageStatus = 'FAILED';
           }
 


### PR DESCRIPTION
Fixed critical bug where message sending failed with 500 error due to missing enum values in database schema.

Changes:
1. Added PENDING status - for messages waiting for provider to accept
2. Added UNDELIVERED status - for temporary delivery failures
3. Updated webhook to properly map 'undelivered' separately from 'failed'
4. Created database migration to add new enum values

Root cause: Backend code was using 'PENDING' status (from Phase 2 real-time improvements) but enum only had SENT, DELIVERED, READ, FAILED.

This prevented any message from being sent as Prisma rejected the invalid enum value during message creation.